### PR TITLE
client: do not require password longer than 8

### DIFF
--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -88,9 +88,6 @@ impl Config {
         if self.password.is_empty() {
             anyhow::bail!("'password' is required");
         }
-        if self.password.len() < 8 {
-            anyhow::bail!("'password' must be at least 8 characters long");
-        }
         if self.listen.is_empty() && self.forward.is_empty() {
             anyhow::bail!("'listen' or 'forward' is required");
         }


### PR DESCRIPTION
Neither go implementation does not have this limitation nor the protocol specification require it. And this breaks the behavior.