### PR TITLE
fix(server): preserve UDP sources and TCP relay lifetimes

### DIFF
--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -35,6 +35,16 @@ on:
       - '.github/**'
 
 jobs:
+  server_tests:
+    name: Server relay regression tests
+    runs-on: ubuntu-26.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo test --locked -p juicity-server --lib
+
   # --------------------------------------------------
   # Package Offline Source Code
   # --------------------------------------------------

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod dialer;
 pub mod inflight;
 pub mod server;
+mod tcp;
 pub mod underlay_socket;
 pub mod udp;

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -1137,111 +1137,21 @@ async fn handle_stream(
     }
 }
 
-/// TCP relay: bidirectional copy between QUIC stream and remote TCP.
-///
-/// Implements per-stream idle timeout: if no data flows in either direction
-/// for [`consts::TCP_RELAY_IDLE_TIMEOUT`], the stream is closed and its
-/// resources (buffers, tasks, Arc refs) are released individually without
-/// waiting for the connection-level idle timeout.
-///
-/// Each successful read or write resets the idle timer, so active transfers
-/// (e.g. large downloads) are never interrupted.
+/// Relay TCP while preserving half-close and sharing one idle deadline.
 async fn handle_tcp_relay(
     send_stream: SendStream,
     recv_stream: RecvStream,
     dialer: Arc<dyn crate::dialer::Dialer>,
     target: &str,
 ) -> anyhow::Result<()> {
-    let target = Arc::from(target);
-
-    let remote = dialer.dial_tcp(&target).await?;
-    let (remote_rx, mut remote_tx) = tokio::io::split(remote);
-    let (mut quic_tx, quic_rx) = (send_stream, recv_stream);
-
-    // Use 16KB buffered readers for bidirectional copy.
-    let mut remote_rx = tokio::io::BufReader::with_capacity(16 * 1024, remote_rx);
-    let mut quic_rx = tokio::io::BufReader::with_capacity(16 * 1024, quic_rx);
-
-    // Spawn idle-timeout monitor tasks — one per direction.
-    // Each wraps a manual copy loop in `tokio::time::timeout`.  A new
-    // timeout is created per chunk, so any successful read/write resets
-    // the timer.  When one direction finishes (or times out), the other
-    // is aborted.
-    let mut remote_to_quic = {
-        let target = target.clone();
-        tokio::spawn(async move {
-            let mut buf = vec![0u8; 16 * 1024];
-            loop {
-                let n = match tokio::time::timeout(
-                    consts::TCP_RELAY_IDLE_TIMEOUT,
-                    tokio::io::AsyncReadExt::read(&mut remote_rx, &mut buf),
-                )
-                .await
-                {
-                    Ok(Ok(0)) => return Ok(()),
-                    Ok(Ok(n)) => n,
-                    Ok(Err(e)) => return Err(e),
-                    Err(_) => {
-                        tracing::debug!(
-                            target = %target,
-                            idle_secs = consts::TCP_RELAY_IDLE_TIMEOUT.as_secs(),
-                            "TCP relay remote→quic idle timeout"
-                        );
-                        return Ok(());
-                    }
-                };
-                if let Err(e) =
-                    tokio::io::AsyncWriteExt::write_all(&mut quic_tx, &buf[..n]).await
-                {
-                    return Err(e);
-                }
-            }
-        })
-    };
-
-    let mut quic_to_remote = {
-        let target = target.clone();
-        tokio::spawn(async move {
-            let mut buf = vec![0u8; 16 * 1024];
-            loop {
-                let n = match tokio::time::timeout(
-                    consts::TCP_RELAY_IDLE_TIMEOUT,
-                    tokio::io::AsyncReadExt::read(&mut quic_rx, &mut buf),
-                )
-                .await
-                {
-                    Ok(Ok(0)) => return Ok(()),
-                    Ok(Ok(n)) => n,
-                    Ok(Err(e)) => return Err(e),
-                    Err(_) => {
-                        tracing::debug!(
-                            target = %target,
-                            idle_secs = consts::TCP_RELAY_IDLE_TIMEOUT.as_secs(),
-                            "TCP relay quic→remote idle timeout"
-                        );
-                        return Ok(());
-                    }
-                };
-                if let Err(e) =
-                    tokio::io::AsyncWriteExt::write_all(&mut remote_tx, &buf[..n]).await
-                {
-                    return Err(e);
-                }
-            }
-        })
-    };
-
-    tokio::select! {
-        r = &mut remote_to_quic => {
-            quic_to_remote.abort();
-            let _ = r;
-        }
-        r = &mut quic_to_remote => {
-            remote_to_quic.abort();
-            let _ = r;
-        }
-    }
-
+    let remote = dialer.dial_tcp(target).await?;
+    crate::tcp::relay(
+        recv_stream,
+        send_stream,
+        remote,
+        consts::TCP_RELAY_IDLE_TIMEOUT,
+    )
+    .await?;
     Ok(())
 }
 
@@ -1368,43 +1278,13 @@ async fn handle_udp_relay(
             let mut guard = SendGuard {
                 send: Some(send_stream),
             };
-            let mut buf = vec![0u8; consts::ETHERNET_MTU];
-            // Pre-allocate frame buffer for reuse across all response datagrams.
-            // Max: trojanc_addr header (up to ~261 bytes) + 2-byte length + payload.
-            let mut frame = Vec::with_capacity(264 + consts::ETHERNET_MTU);
-            // Cache the first response address; subsequent responses come from
-            // the same outbound target so we avoid re-parsing every datagram.
-            let mut cached_addr: Option<protocol::CachedAddr> = None;
-            loop {
-                match tokio::time::timeout(consts::DEFAULT_NAT_TIMEOUT, remote.recv_from(&mut buf))
-                    .await
-                {
-                    Ok(Ok((n, addr))) => {
-                        // Cache the address on first packet to avoid re-parsing
-                        // the address type (string → IPv4/IPv6/Domain) on every
-                        // subsequent datagram in this session.
-                        let cached = cached_addr
-                            .get_or_insert_with(|| protocol::CachedAddr::from_socket_addr(addr));
-                        // Build header directly into the reusable frame buffer,
-                        // eliminating the intermediate Vec allocation.
-                        let pkt_len = (n as u16).to_be_bytes();
-                        frame.clear();
-                        if let Err(e) = protocol::build_trojanc_addr_cached(&mut frame, cached) {
-                            tracing::debug!("build_trojanc_addr_cached error: {:?}", e);
-                            break;
-                        }
-                        frame.extend_from_slice(&pkt_len);
-                        frame.extend_from_slice(&buf[..n]);
-                        if guard.send.as_mut().unwrap().write_all(&frame).await.is_err() {
-                            break;
-                        }
-                    }
-                    Ok(Err(_)) => break,
-                    Err(_) => {
-                        tracing::debug!("UDP relay remote->quic idle timeout");
-                        break;
-                    }
-                }
+            if let Err(e) = crate::udp::relay_responses(
+                remote.as_ref(),
+                guard.send.as_mut().unwrap(),
+            )
+            .await
+            {
+                tracing::debug!("UDP relay remote->quic error: {:?}", e);
             }
         })
     };

--- a/server/src/tcp.rs
+++ b/server/src/tcp.rs
@@ -1,0 +1,76 @@
+use std::io;
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::sync::watch;
+use tokio::time::Instant;
+
+/// Keep the reverse direction alive after EOF, and expire only when neither
+/// direction makes progress. Both copies belong to this future so cancellation
+/// also releases the sockets and streams.
+pub(super) async fn relay<R, W, S>(
+    reader: R,
+    writer: W,
+    remote: S,
+    idle_timeout: Duration,
+) -> io::Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let (remote_reader, remote_writer) = tokio::io::split(remote);
+    let (activity, mut last_activity) = watch::channel(Instant::now());
+    let copy = async {
+        tokio::try_join!(
+            copy_direction(reader, remote_writer, &activity),
+            copy_direction(remote_reader, writer, &activity),
+        )?;
+        Ok(())
+    };
+    let idle = async {
+        loop {
+            let deadline = *last_activity.borrow_and_update() + idle_timeout;
+            tokio::time::sleep_until(deadline).await;
+            if !last_activity.has_changed().unwrap_or(false) {
+                break;
+            }
+        }
+    };
+
+    tokio::select! {
+        result = copy => result,
+        _ = idle => Err(io::Error::new(io::ErrorKind::TimedOut, "TCP relay idle timeout")),
+    }
+}
+
+async fn copy_direction<R, W>(
+    mut reader: R,
+    mut writer: W,
+    activity: &watch::Sender<Instant>,
+) -> io::Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut buf = vec![0; 16 * 1024];
+    loop {
+        let n = reader.read(&mut buf).await?;
+        if n == 0 {
+            return writer.shutdown().await;
+        }
+        activity.send_replace(Instant::now());
+        let mut remaining = &buf[..n];
+        while !remaining.is_empty() {
+            let written = writer.write(remaining).await?;
+            if written == 0 {
+                return Err(io::ErrorKind::WriteZero.into());
+            }
+            activity.send_replace(Instant::now());
+            remaining = &remaining[written..];
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/server/src/tcp/tests.rs
+++ b/server/src/tcp/tests.rs
@@ -1,0 +1,206 @@
+use std::{io, time::Duration};
+
+use tokio::{
+    io::{duplex, split, AsyncReadExt, AsyncWriteExt},
+    time::timeout,
+};
+
+use super::relay;
+
+const IDLE_TIMEOUT: Duration = Duration::from_millis(500);
+const CHUNK_INTERVAL: Duration = Duration::from_millis(100);
+const TEST_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[tokio::test]
+async fn client_half_close_keeps_receiving_remote_response() {
+    timeout(TEST_TIMEOUT, async {
+        let (client, relay_quic) = duplex(4096);
+        let (mut client_read, mut client_write) = split(client);
+        let (relay_read, relay_write) = split(relay_quic);
+        let (relay_remote, mut remote) = duplex(4096);
+        let relay_task = tokio::spawn(relay(relay_read, relay_write, relay_remote, IDLE_TIMEOUT));
+
+        client_write.write_all(b"request").await.unwrap();
+        client_write.shutdown().await.unwrap();
+        let mut request = Vec::new();
+        remote.read_to_end(&mut request).await.unwrap();
+        assert_eq!(request, b"request");
+        remote.write_all(b"response after eof").await.unwrap();
+        remote.shutdown().await.unwrap();
+        let mut response = Vec::new();
+        client_read.read_to_end(&mut response).await.unwrap();
+        assert_eq!(response, b"response after eof");
+        assert!(relay_task.await.unwrap().is_ok());
+    })
+    .await
+    .expect("relay test should complete");
+}
+
+#[tokio::test]
+async fn remote_half_close_keeps_accepting_client_data() {
+    timeout(TEST_TIMEOUT, async {
+        let (client, relay_quic) = duplex(4096);
+        let (mut client_read, mut client_write) = split(client);
+        let (relay_read, relay_write) = split(relay_quic);
+        let (relay_remote, remote) = duplex(4096);
+        let (mut remote_read, mut remote_write) = split(remote);
+        let relay_task = tokio::spawn(relay(relay_read, relay_write, relay_remote, IDLE_TIMEOUT));
+
+        remote_write
+            .write_all(b"remote finished writing")
+            .await
+            .unwrap();
+        remote_write.shutdown().await.unwrap();
+        let mut greeting = Vec::new();
+        client_read.read_to_end(&mut greeting).await.unwrap();
+        assert_eq!(greeting, b"remote finished writing");
+        client_write
+            .write_all(b"client data after eof")
+            .await
+            .unwrap();
+        client_write.shutdown().await.unwrap();
+        let mut received = Vec::new();
+        remote_read.read_to_end(&mut received).await.unwrap();
+        assert_eq!(received, b"client data after eof");
+        assert!(relay_task.await.unwrap().is_ok());
+    })
+    .await
+    .expect("relay test should complete");
+}
+
+#[tokio::test]
+async fn continuous_download_does_not_hit_idle_timeout() {
+    timeout(TEST_TIMEOUT, async {
+        let (client, relay_quic) = duplex(4096);
+        let (mut client_read, mut client_write) = split(client);
+        let (relay_read, relay_write) = split(relay_quic);
+        let (relay_remote, mut remote) = duplex(4096);
+        let relay_task = tokio::spawn(relay(relay_read, relay_write, relay_remote, IDLE_TIMEOUT));
+
+        client_write.write_all(b"download request").await.unwrap();
+        let mut request = [0; 16];
+        remote.read_exact(&mut request).await.unwrap();
+        assert_eq!(&request, b"download request");
+        let mut expected = Vec::new();
+        for _ in 0..12 {
+            remote.write_all(b"download chunk\n").await.unwrap();
+            expected.extend_from_slice(b"download chunk\n");
+            tokio::time::sleep(CHUNK_INTERVAL).await;
+        }
+        remote.shutdown().await.unwrap();
+        let mut downloaded = Vec::new();
+        client_read.read_to_end(&mut downloaded).await.unwrap();
+        assert_eq!(downloaded, expected);
+        client_write.shutdown().await.unwrap();
+        assert!(relay_task.await.unwrap().is_ok());
+    })
+    .await
+    .expect("relay test should complete");
+}
+
+#[tokio::test]
+async fn continuous_upload_does_not_hit_idle_timeout() {
+    timeout(TEST_TIMEOUT, async {
+        let (client, relay_quic) = duplex(4096);
+        let (_client_read, mut client_write) = split(client);
+        let (relay_read, relay_write) = split(relay_quic);
+        let (relay_remote, remote) = duplex(4096);
+        let (mut remote_read, mut remote_write) = split(remote);
+        let relay_task = tokio::spawn(relay(relay_read, relay_write, relay_remote, IDLE_TIMEOUT));
+
+        let mut expected = Vec::new();
+        for _ in 0..12 {
+            client_write.write_all(b"upload chunk\n").await.unwrap();
+            expected.extend_from_slice(b"upload chunk\n");
+            tokio::time::sleep(CHUNK_INTERVAL).await;
+        }
+        client_write.shutdown().await.unwrap();
+        let mut uploaded = Vec::new();
+        remote_read.read_to_end(&mut uploaded).await.unwrap();
+        assert_eq!(uploaded, expected);
+        remote_write.shutdown().await.unwrap();
+        assert!(relay_task.await.unwrap().is_ok());
+    })
+    .await
+    .expect("relay test should complete");
+}
+
+#[tokio::test]
+async fn slow_backpressured_writes_keep_relay_alive() {
+    timeout(TEST_TIMEOUT, async {
+        let (client, relay_quic) = duplex(4096);
+        let (_client_read, mut client_write) = split(client);
+        let (relay_read, relay_write) = split(relay_quic);
+        let (relay_remote, remote) = duplex(1);
+        let (mut remote_read, mut remote_write) = split(remote);
+        let relay_task = tokio::spawn(relay(relay_read, relay_write, relay_remote, IDLE_TIMEOUT));
+        let payload = b"backpressure!";
+        let writer = tokio::spawn(async move {
+            client_write.write_all(payload).await.unwrap();
+            client_write.shutdown().await.unwrap();
+        });
+
+        let mut received = Vec::new();
+        for _ in payload {
+            let mut byte = [0; 1];
+            remote_read.read_exact(&mut byte).await.unwrap();
+            received.extend_from_slice(&byte);
+            tokio::time::sleep(CHUNK_INTERVAL).await;
+        }
+        assert_eq!(received, payload);
+        writer.await.unwrap();
+        remote_write.shutdown().await.unwrap();
+        assert!(relay_task.await.unwrap().is_ok());
+    })
+    .await
+    .expect("backpressured relay should keep making progress");
+}
+
+#[tokio::test]
+async fn inactivity_after_activity_returns_timed_out() {
+    timeout(TEST_TIMEOUT, async {
+        let (client, relay_quic) = duplex(4096);
+        let (_client_read, mut client_write) = split(client);
+        let (relay_read, relay_write) = split(relay_quic);
+        let (relay_remote, mut remote) = duplex(4096);
+        let relay_task = tokio::spawn(relay(
+            relay_read,
+            relay_write,
+            relay_remote,
+            Duration::from_millis(100),
+        ));
+        client_write.write_all(b"x").await.unwrap();
+        let mut received = [0; 1];
+        remote.read_exact(&mut received).await.unwrap();
+        assert_eq!(received, *b"x");
+        let result = relay_task
+            .await
+            .unwrap()
+            .expect_err("idle relay should fail");
+        assert_eq!(result.kind(), io::ErrorKind::TimedOut);
+    })
+    .await
+    .expect("relay test should complete");
+}
+
+#[tokio::test]
+async fn cancelling_relay_closes_both_peers() {
+    timeout(TEST_TIMEOUT, async {
+        let (client, relay_quic) = duplex(4096);
+        let (mut client_read, mut client_write) = split(client);
+        let (relay_read, relay_write) = split(relay_quic);
+        let (relay_remote, mut remote) = duplex(4096);
+        let relay_task = tokio::spawn(relay(relay_read, relay_write, relay_remote, IDLE_TIMEOUT));
+        client_write.write_all(b"x").await.unwrap();
+        let mut activity = [0; 1];
+        remote.read_exact(&mut activity).await.unwrap();
+        assert_eq!(activity, *b"x");
+        relay_task.abort();
+        assert!(relay_task.await.unwrap_err().is_cancelled());
+        let mut byte = [0; 1];
+        assert_eq!(client_read.read(&mut byte).await.unwrap(), 0);
+        assert_eq!(remote.read(&mut byte).await.unwrap(), 0);
+    })
+    .await
+    .expect("relay cancellation should release both peers");
+}

--- a/server/src/udp.rs
+++ b/server/src/udp.rs
@@ -4,8 +4,35 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
 
+use juicity_common::consts;
+use juicity_common::protocol;
 use moka::sync::Cache;
+use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio::sync::Notify;
+
+/// Relay UDP responses to a Juicity stream.
+pub(crate) async fn relay_responses<W: AsyncWrite + Unpin>(
+    remote: &tokio::net::UdpSocket,
+    writer: &mut W,
+) -> anyhow::Result<()> {
+    let mut buf = vec![0u8; consts::ETHERNET_MTU];
+    let mut frame = Vec::with_capacity(264 + consts::ETHERNET_MTU);
+
+    loop {
+        match tokio::time::timeout(consts::DEFAULT_NAT_TIMEOUT, remote.recv_from(&mut buf)).await {
+            Ok(Ok((n, addr))) => {
+                frame.clear();
+                let response_addr = protocol::CachedAddr::from_socket_addr(addr);
+                protocol::build_trojanc_addr_cached(&mut frame, &response_addr)?;
+                frame.extend_from_slice(&(n as u16).to_be_bytes());
+                frame.extend_from_slice(&buf[..n]);
+                writer.write_all(&frame).await?;
+            }
+            Ok(Err(err)) => return Err(err.into()),
+            Err(_) => return Ok(()),
+        }
+    }
+}
 
 /// Options for creating a UDP endpoint
 pub struct UdpEndpointOptions {
@@ -231,4 +258,80 @@ impl UdpEndpointPool {
     }
 }
 
-use juicity_common::consts;
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use juicity_common::protocol;
+    use tokio::io::{AsyncReadExt, DuplexStream};
+
+    use super::relay_responses;
+
+    async fn read_response(reader: &mut DuplexStream) -> (String, u16, Vec<u8>) {
+        let (host, port) = protocol::read_trojanc_addr_async(reader)
+            .await
+            .expect("response address should decode");
+        let mut len = [0u8; 2];
+        reader
+            .read_exact(&mut len)
+            .await
+            .expect("response length should decode");
+        let mut payload = vec![0u8; u16::from_be_bytes(len) as usize];
+        reader
+            .read_exact(&mut payload)
+            .await
+            .expect("response payload should decode");
+        (host, port, payload)
+    }
+
+    #[tokio::test]
+    async fn relay_responses_keeps_each_packet_source_address() {
+        let relay = tokio::net::UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("relay socket should bind");
+        let relay_addr = relay
+            .local_addr()
+            .expect("relay address should be available");
+        let source_one = tokio::net::UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("first source socket should bind");
+        let source_two = tokio::net::UdpSocket::bind("127.0.0.1:0")
+            .await
+            .expect("second source socket should bind");
+        let source_one_addr = source_one
+            .local_addr()
+            .expect("first source address should be available");
+        let source_two_addr = source_two
+            .local_addr()
+            .expect("second source address should be available");
+        let (mut reader, mut writer) = tokio::io::duplex(4096);
+
+        let relay_task = tokio::spawn(async move { relay_responses(&relay, &mut writer).await });
+
+        for (source, address, payload) in [
+            (&source_one, source_one_addr, b"first".as_slice()),
+            (&source_two, source_two_addr, b"second".as_slice()),
+            (&source_one, source_one_addr, b"third".as_slice()),
+        ] {
+            source
+                .send_to(payload, relay_addr)
+                .await
+                .expect("response packet should send");
+            let (host, port, actual_payload) =
+                tokio::time::timeout(Duration::from_secs(1), read_response(&mut reader))
+                    .await
+                    .expect("response should arrive before timeout");
+            assert_eq!(host, address.ip().to_string());
+            assert_eq!(port, address.port());
+            assert_eq!(actual_payload, payload);
+        }
+
+        relay_task.abort();
+        let result = tokio::time::timeout(Duration::from_secs(1), relay_task)
+            .await
+            .expect("relay task should stop after abort");
+        assert!(result
+            .expect_err("aborted relay task should be cancelled")
+            .is_cancelled());
+    }
+}


### PR DESCRIPTION
This fixes three server relay regressions reproduced against v1.0.2 (`69c675a`) with the Go v0.5.0 client on an isolated Linux ARM64 loopback network.

- **UDP source address:** A single SOCKS5 UDP association sending to two echo ports receives the second response with the first port in its address header. Encode the actual source returned by every `recv_from`, while reusing the frame buffer.
- **TCP half-close:** A target that reads the request until EOF and then replies loses its reply. Propagate EOF to the corresponding writer and let the reverse copy complete instead of aborting it.
- **TCP idle timeout:** A continuously active one-way download is terminated when the opposite direction has no application data for 600 seconds. Use one last-activity timestamp for both directions, including partial write progress, and keep both copies owned by the relay future.

The 600-second idle limit and UDP framing/buffer limits are unchanged. No dependency or configuration changes are required.

Validation:

- Added eight server tests covering UDP A/B/A response sources, both half-close directions, continuous upload/download, backpressured partial writes, inactivity after traffic, and cancellation releasing both peers. Added a server library test job to the existing core CI.
- `cargo test --locked -p juicity-server --lib`: all eight tests pass on macOS ARM64 and Linux ARM64.
- `cargo clippy --locked -p juicity-server --all-targets`: completes successfully, with existing warnings in unchanged code.
- Formatting checks for the new TCP module/tests and UDP module, plus `git diff --check`, pass.
- The UDP regression test fails with the original first-address cache and passes with this fix.
- Real Go-client interoperability: Go server and patched Rust server return correct UDP source ports and the complete post-EOF response; original Rust returns a stale UDP port and an empty TCP response.
- Real-time baseline: original Rust closes an active download at **600.173 s**, after the last 595 s record; the same Go-server control receives records through **625 s** and closes only after the target's normal FIN. Neither test shortens the production timeout.
- Patched binary: the same test receives all **125 records / 127,875 bytes** through **620 s**, then sees EOF at **620.838 s** only after the target sends its normal FIN. The concurrent Go control receives the same records and bytes. The short interoperability and long-run tests use the same patched binary (SHA-256 `45398f3addb9acc081273bd8fec9c91422a47ccbf5eb948d89e3b21b2b338bbe`).

The upstream Actions runs currently show `action_required` and have not started any jobs; the local validation results above are independent of CI.
